### PR TITLE
Enable twitter integration for access announcements

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ to add users:
 ./door add
 ```
 
+To announce entrances to Twitter, save the oauth credentials to `./api.cfg`
 
 dependencies: pyserial, zdaemon

--- a/api.cfg
+++ b/api.cfg
@@ -1,0 +1,5 @@
+[Twitter]
+app_key = 
+app_secret = 
+oauth_token = 
+oauth_token_secret = 

--- a/door.py
+++ b/door.py
@@ -5,12 +5,24 @@
 #   to add users: ./door.py add
 #
 from __future__ import print_function
-import subprocess, serial, sys, os
+import subprocess, serial, sys, os, time, ConfigParser, twython
 from time import sleep
 from octopus import Octopus
 
 unlock = "1 > /sys/class/gpio/gpio17/value"
 lock = "0 > /sys/class/gpio/gpio17/value"
+
+os.environ['TZ'] = 'GMT+16'
+time.tzset()
+
+config_parser = ConfigParser.SafeConfigParser()
+config_parser.read('api.cfg')
+api_config = {}
+try:
+    api_config = dict(config_parser.items('Twitter'))
+except ConfigParser.NoSectionError:
+    pass
+api = twython.Twython(**api_config)
 
 class Door:
     def __init__(self, seconds=5):
@@ -21,10 +33,13 @@ class Door:
 
     def open(self):
         print("opening...")
-	os.popen("echo 1 > /sys/class/gpio/gpio17/value")
-	sleep(self.seconds)
+        os.popen("echo 1 > /sys/class/gpio/gpio17/value")
+        sleep(self.seconds)
         os.popen("echo 0 > /sys/class/gpio/gpio17/value")
-	
+        try:
+            api.update_status(status='Someone entered DSL at '+time.strftime('%H:%M:%S'))
+        except Exception as error:
+            print(error.message)
 
     def run(self, auth_module):
         while True:

--- a/octopus.py
+++ b/octopus.py
@@ -4,7 +4,7 @@
 #   to run: ./octopus.py
 #
 from __future__ import print_function
-import shutil, json, os, re, subprocess, serial, signal, sys
+import shutil, json, os, re, subprocess, serial, signal, sys, errno
 from hashlib import sha256 as hashfun
 from time import sleep, ctime
 
@@ -23,10 +23,22 @@ class Octopus:
         self.users = self.read_users()
 
     def read_users(self):
-        return json.load(open(self.userfilename))
+        users = {}
+        try:
+            users = json.load(open(self.userfilename))
+        except IOError as error:
+            if error.errno == errno.ENOENT:
+                print("[WARNING] Database is empty. Please add at least one user ASAP!")
+            else:
+                raise error
+        return users
 
     def backup(self):
-        shutil.copy(self.userfilename, "bkp/{0}.txt".format(ctime())) 
+        try:
+            shutil.copy(self.userfilename, "{0}/{1}.txt".format(bkpdir, ctime())) 
+        except IOError as error:
+            if error.errno != errno.ENOENT:
+                raise error
 
     def save_users(self):
         self.backup()


### PR DESCRIPTION
This commit enables the publishing of door access announcements to Twitter, based on the original work by @tomgrek.

This commit differs from the original work by factoring out the credentials for publishing tweets into a separate config file `api.cfg`.

Also, the code wraps the twitter api call in a try-except block to improve robustness, so that exceptions thrown by twython (e.g. caused by loss of Internet connection)  will not crash the door access system.
